### PR TITLE
Responsive fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thebadge-ui-library",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/assets/scss/classes/_gradient.classes.scss.d.ts
+++ b/src/assets/scss/classes/_gradient.classes.scss.d.ts
@@ -4,6 +4,7 @@ export const backgroundGradient2: string
 export const backgroundGradient3: string
 export const backgroundGradient4: string
 export const backgroundGradient5: string
+export const backgroundGradientBackground: string
 export const backgroundGradientHeader: string
 export const backgroundInherit: string
 export const black: string
@@ -22,6 +23,7 @@ export const gradient2: string
 export const gradient3: string
 export const gradient4: string
 export const gradient5: string
+export const gradientBackground: string
 export const gradientHeader: string
 export const green: string
 export const greenBorder: string

--- a/src/assets/scss/global.scss.d.ts
+++ b/src/assets/scss/global.scss.d.ts
@@ -36,6 +36,7 @@ export const backgroundGradient2: string
 export const backgroundGradient3: string
 export const backgroundGradient4: string
 export const backgroundGradient5: string
+export const backgroundGradientBackground: string
 export const backgroundGradientHeader: string
 export const backgroundInherit: string
 export const black: string
@@ -178,6 +179,7 @@ export const gradient2: string
 export const gradient3: string
 export const gradient4: string
 export const gradient5: string
+export const gradientBackground: string
 export const gradientHeader: string
 export const green: string
 export const greenBorder: string

--- a/src/assets/scss/variables/_fonts.variables.module.scss
+++ b/src/assets/scss/variables/_fonts.variables.module.scss
@@ -18,22 +18,22 @@ $font-weight-black: 900;
 // headlines
 // h1
 $font-size-h1: 60;
-$line-height-h1: 68px;
+$line-height-h1: 113%;
 // h2
 $font-size-h2: 50;
-$line-height-h2: 60px;
+$line-height-h2: 120%;
 // h3
 $font-size-h3: 44;
-$line-height-h3: 44px;
+$line-height-h3: 100%;
 // h4
 $font-size-h4: 21;
-$line-height-h4: 24px;
+$line-height-h4: 115%;
 // h5
 $font-size-h5: 20;
-$line-height-h5: 24px;
+$line-height-h5: 120%;
 // h6
 $font-size-h6: 18;
-$line-height-h6: 21px;
+$line-height-h6: 117%;
 
 // bodies
 // Body 1
@@ -55,19 +55,19 @@ $line-height-body4: 16px;
 // titles
 // Title 1
 $font-size-title1: 23;
-$line-height-title1: 28px;
+$line-height-title1: 121%;
 // Title 2
 $font-size-title2: 28;
-$line-height-title2: 30px;
+$line-height-title2: 107%;
 // Title 3
 $font-size-title3: 35;
-$line-height-title3: 35px;
+$line-height-title3: 100%;
 // Title 4
 $font-size-title4: 22;
-$line-height-title4: 24px;
+$line-height-title4: 110%;
 // Title 5
 $font-size-title5: 21;
-$line-height-title5: 24px;
+$line-height-title5: 114%;
 
 // subtitles
 $font-size-subtitle1: 16;

--- a/src/assets/scss/variables/_fonts.variables.module.scss
+++ b/src/assets/scss/variables/_fonts.variables.module.scss
@@ -17,74 +17,74 @@ $font-weight-black: 900;
 
 // headlines
 // h1
-$font-size-h1: 60px;
+$font-size-h1: 60;
 $line-height-h1: 68px;
 // h2
-$font-size-h2: 50px;
+$font-size-h2: 50;
 $line-height-h2: 60px;
 // h3
-$font-size-h3: 44px;
+$font-size-h3: 44;
 $line-height-h3: 44px;
 // h4
-$font-size-h4: 21px;
+$font-size-h4: 21;
 $line-height-h4: 24px;
 // h5
-$font-size-h5: 20px;
+$font-size-h5: 20;
 $line-height-h5: 24px;
 // h6
-$font-size-h6: 18px;
+$font-size-h6: 18;
 $line-height-h6: 21px;
 
 // bodies
 // Body 1
-$font-size-body1: 19px;
+$font-size-body1: 19;
 $line-height-body1: 28px;
 // Body 2
-$font-size-body2: 18px;
+$font-size-body2: 18;
 $line-height-body2: 24px;
 // Body 3
-$font-size-body3: 20px;
+$font-size-body3: 20;
 $line-height-body3: 26px;
 // Body 3
-$font-size-body3: 18px;
+$font-size-body3: 18;
 $line-height-body3: 24px;
 // Body 4
-$font-size-body4: 12px;
+$font-size-body4: 12;
 $line-height-body4: 16px;
 
 // titles
 // Title 1
-$font-size-title1: 23px;
+$font-size-title1: 23;
 $line-height-title1: 28px;
 // Title 2
-$font-size-title2: 28px;
+$font-size-title2: 28;
 $line-height-title2: 30px;
 // Title 3
-$font-size-title3: 35px;
+$font-size-title3: 35;
 $line-height-title3: 35px;
 // Title 4
-$font-size-title4: 22px;
+$font-size-title4: 22;
 $line-height-title4: 24px;
 // Title 5
-$font-size-title5: 21px;
+$font-size-title5: 21;
 $line-height-title5: 24px;
 
 // subtitles
-$font-size-subtitle1: 16px;
+$font-size-subtitle1: 16;
 $line-height-subtitle1: 24px;
-$font-size-subtitle2: 14px;
+$font-size-subtitle2: 14;
 $line-height-subtitle2: 16px;
 
 // button
-$font-size-button: 18px;
+$font-size-button: 18;
 $line-height-button: 20px;
 
 // caption
-$font-size-caption: 12px;
+$font-size-caption: 12;
 $line-height-caption: 14px;
 
 // overline
-$font-size-overline: 10px;
+$font-size-overline: 10;
 $line-height-overline: 12px;
 
 $default: 1;

--- a/src/assets/scss/variables/_gradient.variables.module.scss.d.ts
+++ b/src/assets/scss/variables/_gradient.variables.module.scss.d.ts
@@ -14,6 +14,7 @@ export const gradient2: string
 export const gradient3: string
 export const gradient4: string
 export const gradient5: string
+export const gradientBackground: string
 export const gradientHeader: string
 export const green: string
 export const greenBorder: string

--- a/src/assets/scss/variables/variables.module.scss.d.ts
+++ b/src/assets/scss/variables/variables.module.scss.d.ts
@@ -42,6 +42,7 @@ export const gradient2: string
 export const gradient3: string
 export const gradient4: string
 export const gradient5: string
+export const gradientBackground: string
 export const gradientHeader: string
 export const green: string
 export const greenBorder: string

--- a/src/components/molecules/Stepper/Stepper.tsx
+++ b/src/components/molecules/Stepper/Stepper.tsx
@@ -103,7 +103,7 @@ export const Stepper = ({
               onEntering={onEnteringSwitchTransition}
             >
               <AnimateHeight duration={400} height={selectedElementHeight}>
-                <Box ref={elementRefs[selectedElement]}>{elements[selectedElement]}</Box>
+                <Box ref={elementRefs[selectedElement]}>{elements ? elements[selectedElement] : null}</Box>
               </AnimateHeight>
             </CSSTransition>
           </SwitchTransition>

--- a/src/components/molecules/Stepper/Stepper.tsx
+++ b/src/components/molecules/Stepper/Stepper.tsx
@@ -103,7 +103,7 @@ export const Stepper = ({
               onEntering={onEnteringSwitchTransition}
             >
               <AnimateHeight duration={400} height={selectedElementHeight}>
-                <Box ref={elementRefs[selectedElement]}>{elements ? elements[selectedElement] : null}</Box>
+                <Box ref={elementRefs[selectedElement]}>{elements[selectedElement]}</Box>
               </AnimateHeight>
             </CSSTransition>
           </SwitchTransition>


### PR DESCRIPTION
- [x] Remove units on fontSize

Comparative when it's used on the landing page.

Without responsive font:
![image](https://user-images.githubusercontent.com/21246763/210277579-dcd9f4a7-e4dd-4d2c-98bf-9b4e12a675d2.png)

With responsive font:
![image](https://user-images.githubusercontent.com/21246763/210277999-a853f093-6a13-43ae-a8a9-5f717f21a796.png)

----

Without responsive font:
![image](https://user-images.githubusercontent.com/21246763/210277630-bac57566-63de-4cfd-b6fd-c9a2c87a33c2.png)

With responsive font:
![image](https://user-images.githubusercontent.com/21246763/210277959-3b9ae89b-bce7-4687-838e-9e17ba2aaf00.png)

----

Without responsive font:
![image](https://user-images.githubusercontent.com/21246763/210277892-7eb81af2-6050-4a00-8cae-e92a4590d147.png)

With responsive font:
![image](https://user-images.githubusercontent.com/21246763/210277939-d0a5d813-25eb-4950-98c1-0673c2e13b08.png)
