### PR TITLE
Remove global fonts, as they need to be loaded with MUI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thebadge-ui-library",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/assets/scss/_defaults.scss
+++ b/src/assets/scss/_defaults.scss
@@ -2,7 +2,6 @@
 @use 'variables/color.variables.module' as *;
 
 :root, body {
-  font-family: $font-the-badge-web;
   font-weight: $font-weight-normal;
   word-spacing: 1px;
   -ms-text-size-adjust: 100%;  /* stylelint-disable-line property-no-vendor-prefix */

--- a/src/assets/scss/_fonts.scss
+++ b/src/assets/scss/_fonts.scss
@@ -9,7 +9,6 @@
 }
 
 @font-face {
-  font-family: $font-the-badge-web;
   font-style: normal;
   font-weight: $font-weight-bold;
   src: url('https://fonts.googleapis.com/css2?family=Mulish:wght@700&display=swap');
@@ -17,7 +16,6 @@
 }
 
 @font-face {
-  font-family: $font-the-badge-web;
   font-style: normal;
   font-weight: $font-weight-thin;
   src: url('https://fonts.googleapis.com/css2?family=Mulish:wght@300&display=swap');

--- a/src/components/molecules/Stepper/Stepper.tsx
+++ b/src/components/molecules/Stepper/Stepper.tsx
@@ -2,7 +2,7 @@ import { TBColor } from '@assets/defaultTheme'
 import colors from '@assets/scss/variables/_color.variables.module.scss'
 import { SpinningArrow } from '@components/atoms/SpinningArrow/SpinningArrow'
 import colorStringIsTBColor from '@helpers/IsTBColor'
-import { Box } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 import React, { createRef, RefObject, useMemo, useState } from 'react'
 import { CSSTransition, SwitchTransition } from 'react-transition-group'
 
@@ -128,17 +128,15 @@ const StepperTitle = ({ children, color, glow }: React.PropsWithChildren<Stepper
     if (typeof children === 'string') {
       const [firstWord, ...rest] = children.split(' ')
       return (
-        <>
+        <Typography
+          className={[`stepper__title`, `color--${color ?? ''}`, glow ? 'stepper__title--glow' : ''].join(' ')}
+        >
           <span>{firstWord}</span> {rest.join(' ')}
-        </>
+        </Typography>
       )
     }
     return children
   }
 
-  return (
-    <div className={[`stepper__title`, `color--${color ?? ''}`, glow ? 'stepper__title--glow' : ''].join(' ')}>
-      {getElement(children)}
-    </div>
-  )
+  return <div>{getElement(children)}</div>
 }

--- a/src/components/molecules/Stepper/stepper.scss
+++ b/src/components/molecules/Stepper/stepper.scss
@@ -16,7 +16,6 @@
   }
 
   &__title {
-    font-family: variables.$font-the-badge-web;
     font-style: normal;
     font-weight: 700;
     font-size: 28px;


### PR DESCRIPTION
To prevent collisions or overlapping with the loaded fonts on the Web and Dapp, we remove all the global font configs, and we trust on the Next/Font + MUI font loading at the moment that we use them. 