### PR TITLE
Improve build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@thebadge/ui-library",
   "version": "1.7.4",
   "license": "MIT",
-  "main": "dist/index.js",
   "module": "dist/index.es.js",
+  "files": ["dist/"],
   "scripts": {
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,13 +18,11 @@ export default [
     input: './src/index.ts',
     output: [
       {
-        file: 'dist/index.js',
-        format: 'cjs',
-      },
-      {
-        file: 'dist/index.es.js',
+        dir: 'dist',
         format: 'es',
         exports: 'named',
+        preserveModules: true,
+        sourcemap: true,
       },
     ],
     plugins: [
@@ -69,6 +67,7 @@ export default [
       // TS
       typescript({
         sourceMap: true,
+        declarationDir: 'dist/types',
       }),
       resolve(),
       external(),


### PR DESCRIPTION
Improve build removing cjs
Preserve modular exports

Test using  `npm pack --dry-run`

### Before
```
npm notice === Tarball Details === 
npm notice name:          @thebadge/ui-library                    
npm notice version:       1.7.4                                   
npm notice filename:      @thebadge/ui-library-1.7.4.tgz          
npm notice package size:  2.7 MB                                  
npm notice unpacked size: 9.7 MB                                  
npm notice shasum:        64c14cf91b7b0f45b8422b655f85753d64a71c80
npm notice integrity:     sha512-KwjlmbifZV2qH[...]XjTKE7SnyaAGg==
npm notice total files:   295                                     
npm notice 
thebadge-ui-library-1.7.4.tgz
```

### After
```
npm notice === Tarball Details === 
npm notice name:          @thebadge/ui-library                    
npm notice version:       1.7.4                                   
npm notice filename:      @thebadge/ui-library-1.7.4.tgz          
npm notice package size:  88.3 kB                                 
npm notice unpacked size: 340.0 kB                                
npm notice shasum:        12c0fe70e4e6a83b4ba7bcc896a364c48dd96aab
npm notice integrity:     sha512-iuo6fyGIpSxiJ[...]e1WUSQulSbzAg==
npm notice total files:   180                                     
npm notice 
thebadge-ui-library-1.7.4.tgz
```